### PR TITLE
fix: Include string.h for strcmp

### DIFF
--- a/wavdata.c
+++ b/wavdata.c
@@ -31,6 +31,7 @@
 
 #include "wavdata.h"
 #include <stdlib.h>
+#include <string.h>
 
 /* Loads a wave header in memory, and checks for its validity. */
 /* returns NULL on error, a malloced() wavSound* otherwise.    */


### PR DESCRIPTION
Later gcc complains about missing includes, so lets add it here.

```
make
gcc -c main.c
gcc -c wavdata.c
wavdata.c: In function ‘loadWaveHeader’:
wavdata.c:59:13: error: implicit declaration of function ‘strcmp’ [-Wimplicit-function-declaration]
   59 |         if (strcmp(c, "RIFF") != 0) {
      |             ^~~~~~
wavdata.c:34:1: note: include ‘<string.h>’ or provide a declaration of ‘strcmp’
   33 | #include <stdlib.h>
  +++ |+#include <string.h>
   34 |
make: *** [Makefile:13: wavdata.o] Error 1
```